### PR TITLE
🔧 fix: Remove unexported utils in ghreleaser

### DIFF
--- a/ghrelease/main.go
+++ b/ghrelease/main.go
@@ -43,9 +43,6 @@ type Ghrelease struct {
 	//
 	// +private
 	Tag string
-
-	// Utils
-	utils *dagger.Utilsverse
 }
 
 // New creates a new Ghrelease instance.
@@ -63,8 +60,6 @@ func New(
 		Token:  token,
 		Repo:   repo,
 		Assets: assets,
-
-		utils: dag.Utilsverse(),
 	}
 }
 
@@ -97,7 +92,7 @@ func (m *Ghrelease) Upload(ctx context.Context) error {
 	dist := m.Assets
 
 	if m.DoFlatten {
-		dist = m.utils.FlattenNameOsArch(m.Assets)
+		dist = dag.Utilsverse().FlattenNameOsArch(m.Assets)
 	}
 
 	entries, err := dist.Glob(ctx, "*")


### PR DESCRIPTION
* 🔧 Fixes a problem where the `utils` isn't getting exported via JSON unmarshaling which then causes a panic. Instead, just call into `dag.Utilsverse().FlattenNameOsArch(m.Assets)` directly: this is what seems to be the right convention - see https://github.com/sagikazarmark/daggerverse/tree/main/registry-config