### PR TITLE
✨ feat: Upgrade golangci-lint base to Go 1.26

### DIFF
--- a/golangcilint/main.go
+++ b/golangcilint/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	golangciLintImage string = "golangci/golangci-lint:v2.8.0"
+	golangciLintImage string = "golangci/golangci-lint:v2.11"
 )
 
 //go:embed .golangci.yml


### PR DESCRIPTION
Uses `golangci/golangci-lint:v2.11` for Golangci-lint image which has a Go 1.26 base