### PR TITLE
🔧 fix: bump dagger v0.20.6 → v0.20.8

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/bucketupload/dagger.json
+++ b/bucketupload/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "bucketuploader",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
   }

--- a/checksum/dagger.json
+++ b/checksum/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "checksumer",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
   }

--- a/ghcontrib/dagger.json
+++ b/ghcontrib/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "ghcontrib",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
   }

--- a/ghrelease/dagger.json
+++ b/ghrelease/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "ghrelease",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
   },

--- a/go/dagger.json
+++ b/go/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "go",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
   }

--- a/golangcilint/dagger.json
+++ b/golangcilint/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "golangcilint",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
   }

--- a/utils/dagger.json
+++ b/utils/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
   }


### PR DESCRIPTION
## Summary

- The release pipeline has been failing because the engine pinned in each module's `dagger.json` (v0.20.6) and the CLI installed by `dagger-for-github` no longer round-trip cleanly with the current daggerverse modules. The version handshake fails before `dagger call` reaches user code.
- Bumps `engineVersion` in every module (`bucketupload`, `checksum`, `ghcontrib`, `ghrelease`, `go`, `golangcilint`, `utils`) and `DAGGER_VERSION` in the PR workflow to v0.20.8, matching the rest of the org repos (e.g. `paper` PR #40) that have already moved.

Refs PCC-543

## Test plan

- [ ] PR workflow passes on this PR
- [ ] Downstream consumers (paper, tapes-extproc, etc.) keep working after this merges